### PR TITLE
Fix "Running Set ECS PHP Config Sets" test

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ composer require symplify/easy-coding-standard-prefixed --dev
 wget https://github.com/symplify/easy-coding-standard-prefixed/blob/master/ecs.phar?raw=true
 ```
 
-### Non-Prefixed Version 
+### Non-Prefixed Version
 
 Head over to the ["Easy Coding Standard" repository](https://github.com/symplify/easy-coding-standard) for more information.
 
 ## Use
 
 ```bash
-vendor/bin/ecs check src --set dead-code --dry-run
+vendor/bin/ecs check src --set psr12
 ```

--- a/ecs-php.php
+++ b/ecs-php.php
@@ -8,6 +8,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
 
     $parameters->set(Option::SETS, [
-        SetList::DEAD_CODE
+        SetList::PSR_12
     ]);
 };


### PR DESCRIPTION
Usage of deprecated dead-code set in tests was making them fail. 